### PR TITLE
Update zsh-completions.plugin.zsh to correctly resolve $0

### DIFF
--- a/zsh-completions.plugin.zsh
+++ b/zsh-completions.plugin.zsh
@@ -1,1 +1,7 @@
-fpath=( ${0:h}/src/macOS ${0:h}/src/go ${0:h}/src/zsh "${fpath[@]}" )
+
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+
+if [[ $PMSPEC != *f* ]] {
+    fpath=( "${0:h}/src/macOS" "${0:h}/src/go" "${0:h}/src/zsh" "${fpath[@]}" )
+}

--- a/zsh-completions.plugin.zsh
+++ b/zsh-completions.plugin.zsh
@@ -1,7 +1,6 @@
+#!/usr/bin/env zsh
 
 0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
 0="${${(M)0:#/*}:-$PWD/$0}"
 
-if [[ $PMSPEC != *f* ]] {
-    fpath=( "${0:h}/src/macOS" "${0:h}/src/go" "${0:h}/src/zsh" "${fpath[@]}" )
-}
+fpath=( "${0:h}/src/macOS" "${0:h}/src/go" "${0:h}/src/zsh" "${fpath[@]}" )


### PR DESCRIPTION
I updated `zsh-completions.plugin.zsh` to follow [zsh plugin standard](https://github.com/zdharma/Zsh-100-Commits-Club/blob/master/Zsh-Plugin-Standard.adoc)'s recommendations.
Now it will work for [zpm](https://github.com/zpm-zsh/zpm) plugin manager and likely some others.